### PR TITLE
zmiana miejsca wczytania S0, aby bylo zgodne z tabela dzialania

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -364,8 +364,8 @@ public:
             rxPtr->parallelInput(txPtr);
 
         // M S3 S2 S1 S0
-        if(Rc.getValue()==0 || Rc.getValue()==1 || Rc.getValue()==2) command.serialInput(uc[6]);
-        if(Rc.getValue()==0 || Rc.getValue()==1) command.serialInput(uc[7]);
+        if(Rc.getValue()==0 || Rc.getValue()==1) command.serialInput(uc[6]);
+        if(Rc.getValue()==0 || Rc.getValue()==1 || Rc.getValue()==2) command.serialInput(uc[7]);
 
         ++Rc;
         if(Rc.getValue()==0) ++RI;


### PR DESCRIPTION
Symulator działał tak, że wartość S0 miała zostać wpisana na 6 (7 licząc od 1) pozycji trzeciego mikrocyklu instrukcji:
# linia 2; RC=RA*RB
00000000 M=0, S3=0
00110011 # RA -> R1; S2=1, S1=1
01010110 # RB -> R2; S0=1
10001100 # Alu -> RC
W tabeli działania pisze natomiast tak:
W1 W2
M   S3
S2  S1
X    S0
X    X,
czyli S0 powinno zostać wpisane na ostatniej pozycji.
<img width="833" height="285" alt="image" src="https://github.com/user-attachments/assets/7ee511d5-0d63-4602-8b59-975d6bf9227b" />
